### PR TITLE
duplacate msg header

### DIFF
--- a/cmd/xtemplate/go.mod
+++ b/cmd/xtemplate/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/cockroachdb/errors v1.8.6
 	github.com/smartystreets/goconvey v1.6.4
-	github.com/youthlin/t v0.0.5
+	github.com/youthlin/t v0.0.8
 )
 
 require (

--- a/cmd/xtemplate/main.go
+++ b/cmd/xtemplate/main.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version the version
-var Version string = "v0.0.5"
+var Version string = "v0.0.9"
 
 //go:embed lang
 var embedLangs embed.FS
@@ -52,7 +52,7 @@ func buildParam() *internal.Param {
 		input    = flag.String("i", "", t.T("input file pattern"))
 		left     = flag.String("left", "{{", t.T("left delim"))
 		right    = flag.String("right", "}}", t.T("right delim"))
-		keywords = flag.String("k", "", t.T("keywords e.g.: gettext;T:1;N1,2;X:1c,2;XN:1c,2,3"))
+		keywords = flag.String("k", "", t.T("keywords e.g.: gettext;T:1;N:1,2;X:1c,2;XN:1c,2,3"))
 		fun      = flag.String("f", "", t.T("function names of template"))
 		output   = flag.String("o", "", t.T("output file, - is stdout"))
 		debug    = flag.Bool("d", false, t.T("debug mode"))

--- a/translator/file.go
+++ b/translator/file.go
@@ -106,7 +106,9 @@ func (file *File) initHeader() {
 				kv := find[0]
 				k := strings.TrimSpace(kv[1])
 				v := strings.TrimSpace(kv[2])
-				headers[k] = v
+				if _, ok := headers[k]; !ok {
+					headers[k] = v
+				}
 			}
 		}
 		file.headers = headers


### PR DESCRIPTION
使用 `msgcat` 合并多个 pot 模板时，文件头会重复，生成的 po 文件中文件头也会重复。
因此需要在读取 po 文件时，忽略重复的文件头