### PR TITLE
feat: xtemplate支持无须传入模板函数/复数翻译fallback优化支持中文免写复数

### DIFF
--- a/cmd/xtemplate/internal/run.go
+++ b/cmd/xtemplate/internal/run.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
+	"regexp"
 	"text/template/parse"
 
 	"github.com/cockroachdb/errors"
@@ -13,6 +14,27 @@ import (
 )
 
 var noopFun = func() string { return "" }
+
+// templateBuiltins 是 Go template 内置关键字，不应被当作自定义函数注册。
+var templateBuiltins = map[string]bool{
+	"if": true, "else": true, "end": true, "range": true, "with": true,
+	"template": true, "define": true, "block": true, "break": true, "continue": true,
+}
+
+// identPattern 匹配模板中所有合法 Go 标识符（字母或下划线开头）。
+// 扫描所有标识符并注册为 noop 函数，比精确匹配函数调用位置更简单可靠。
+var identPattern = regexp.MustCompile(`[a-zA-Z_]\w*`)
+
+// scanFuncNames 从模板源码中扫描所有标识符，排除内置关键字，作为候选函数名。
+func scanFuncNames(src string) map[string]bool {
+	names := make(map[string]bool)
+	for _, name := range identPattern.FindAllString(src, -1) {
+		if !templateBuiltins[name] {
+			names[name] = true
+		}
+	}
+	return names
+}
 
 // Run 运行解析任务
 func Run(param *Param) (err error) {
@@ -63,10 +85,27 @@ func printErr(format string, args ...interface{}) {
 // resolveOneFile 处理每个文件
 func resolveOneFile(filename string, ctx *Context) error {
 	ctx.debugPrint("resolve one file: filename=%v", filename)
+
+	// 读取文件内容，自动扫描模板中使用的函数名并注册为 noop，
+	// 避免用户必须通过 -f 手动指定所有模板函数。
+	src, err := os.ReadFile(filename)
+	if err != nil {
+		return errors.Wrapf(err, t.T("failed to read file %v"), filename)
+	}
+	funcs := make(template.FuncMap, len(ctx.Functions)+8)
+	for k, v := range ctx.Functions {
+		funcs[k] = v
+	}
+	for name := range scanFuncNames(string(src)) {
+		if _, ok := funcs[name]; !ok {
+			funcs[name] = noopFun
+		}
+	}
+
 	tmpl, err := template.New("").
 		Delims(ctx.Left, ctx.Right).
-		Funcs(ctx.Functions).
-		ParseFiles(filename)
+		Funcs(funcs).
+		Parse(string(src))
 	if err != nil {
 		return errors.Wrapf(err, t.T("failed to parse file %v"), filename)
 	}

--- a/cmd/xtemplate/internal/run_test.go
+++ b/cmd/xtemplate/internal/run_test.go
@@ -21,7 +21,7 @@ func newTestContext() *Context {
 			{Name: "X", MsgCtxt: 1, MsgID: 2},
 			{Name: "XN", MsgCtxt: 1, MsgID: 2, MsgID2: 3},
 		},
-		Functions: template.FuncMap{"T": noopFun, "X": noopFun},
+		Functions: template.FuncMap{},
 		entries:   make(map[string]*translator.Entry),
 	}
 }
@@ -75,7 +75,6 @@ func Test_run(t *testing.T) {
 			Left:       "{{",
 			Right:      "}}",
 			Keyword:    "T;X:1c,2;N:1,2;XN:1c,2,3",
-			Function:   "T",
 			OutputFile: "-",
 		})
 		So(err, ShouldBeNil)

--- a/f/format.go
+++ b/f/format.go
@@ -22,8 +22,12 @@ func Format(format string, args ...interface{}) string {
 	return fmt.Sprintf(format, args...)
 }
 
-// DefaultPlural if n == 1 return singular form, else return plural form
+// DefaultPlural 根据 n 选择单数或复数形式。
+// 当 msgIDPlural 为空时（例如源语言本身没有复数区分），直接使用 msgID。
 func DefaultPlural(msgID, msgIDPlural string, n int64, args ...interface{}) string {
+	if msgIDPlural == "" {
+		return Format(msgID, args...)
+	}
 	if n != 1 {
 		return Format(msgIDPlural, args...)
 	}

--- a/translator/file.go
+++ b/translator/file.go
@@ -46,6 +46,13 @@ func (file *File) XN64(msgCtxt, msgID, msgIDPlural string, n int64, args ...inte
 	if !ok {
 		return f.DefaultPlural(msgID, msgIDPlural, n, args...)
 	}
+	// 条目存在但没有复数形式（MsgID2 为空且 MsgStrN 也为空），直接使用单数翻译。
+	if entry.MsgID2 == "" && len(entry.MsgStrN) == 0 {
+		if entry.MsgStr != "" {
+			return f.Format(entry.MsgStr, args...)
+		}
+		return f.Format(msgID, args...)
+	}
 	plural := file.getPlural()
 	if plural.totalForms <= 0 || plural.fn == nil {
 		return f.DefaultPlural(msgID, msgIDPlural, n, args...)


### PR DESCRIPTION
- `xtemplate` 此前必须传入 `-f` 选项，以保证能够解析含有函数的模板，但模板依赖的函数通常不好枚举，因此我们支持自动识别（虽然用正则可能会多识别，但多注册一些函数并没有副作用）可以免传入该选项。（不过依然可以手动传入）
- 当源代码是中文时，因为中文无复数，因此我们在 `N`, `N64` 等复数翻译方法上，支持免写复数形式